### PR TITLE
fix(prepublish): added module, and exports in prepublish script

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ function App() {
         width: '75vw',
         height: '75vh',
       }}
+      ref={ref}
     />
   );
 }
@@ -150,6 +151,8 @@ interface Props {
 ```
 
 To know more about these props, check out [API.md](https://github.com/novnc/noVNC/blob/master/docs/API.md#properties).
+
+You can pass a `ref` to the `VncScreen` component, and access the `connect()` and `disconnect()` methods from the library. Check out [#18](https://github.com/roerohan/react-vnc/issues/18) for more details.
 
 <!-- ROADMAP -->
 ## Roadmap

--- a/package.json
+++ b/package.json
@@ -27,7 +27,13 @@
   "files": [
     "dist/"
   ],
-  "repository": "https://github.com/roerohan/react-vnc/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/roerohan/react-vnc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/roerohan/react-vnc/issues"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.6",

--- a/prepublish.js
+++ b/prepublish.js
@@ -21,6 +21,8 @@ fs.writeFileSync('package.json', JSON.stringify({
 	repository: pkg.repository,
 	keywords: pkg.keywords,
 	main: pkg.main,
+	module: pkg.module,
+	exports: pkg.exports,
 	typings: pkg.typings,
 	publishConfig: pkg.publishConfig,
 	dependencies,

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,10 +1,19 @@
 const fs = require('fs');
 const pkg = require('./package.json');
 
+// NOTE(roerohan): remove dependencies that are not needed for the library.
 const {
 	react,
 	'react-scripts': reactScripts,
 	'react-dom': reactDom,
+	'@testing-library/jest-dom': testingLibraryjestDom,
+	'@testing-library/react': testingLibraryReact,
+	'@testing-library/user-event': testingLibraryUserEvent,
+	'@types/jest': typesJest,
+	'@types/node': typesNode,
+	'@types/react': typesReact,
+	'@types/react-dom': typesReactDom,
+	'web-vitals': webVitals,
 	...dependencies
 } = pkg.dependencies;
 


### PR DESCRIPTION
The prepublish script did not include `module` and `exports`, adding them here.