### PR TITLE
fix(rfb): expose rfb in VncScreen useImperativeHandle

### DIFF
--- a/src/lib/VncScreen.tsx
+++ b/src/lib/VncScreen.tsx
@@ -35,6 +35,7 @@ export type VncScreenHandle = {
     connect: () => void;
     disconnect: () => void;
     connected: boolean;
+    rfb: RFB | null;
 };
 
 const VncScreen: React.ForwardRefRenderFunction<VncScreenHandle, Props> = (props, ref) => {
@@ -212,6 +213,7 @@ const VncScreen: React.ForwardRefRenderFunction<VncScreenHandle, Props> = (props
         connect,
         disconnect,
         connected: connected.current,
+        rfb: rfb.current,
     }));
 
     useEffect(() => {


### PR DESCRIPTION
#25 #24 

The `rfb` object is also exposed with `vncScreenRef`, so it need not be assigned to a separate `ref` by getting it from the `onConnect` callback.