### PR TITLE
fix: wsProtocols should take string|string[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ interface RFBOptions {
         target?: string;
     };
     repeaterID: string;
-    wsProtocols: string;
+    wsProtocols: string | string[];
 }
 ```
 

--- a/src/lib/VncScreen.tsx
+++ b/src/lib/VncScreen.tsx
@@ -15,7 +15,7 @@ export interface RFBOptions {
         target?: string;
     };
     repeaterID: string;
-    wsProtocols: string;
+    wsProtocols: string | string[];
 }
 
 export interface Props {


### PR DESCRIPTION
## Description

Change the type of `wsProtocols` from `string` to `string | string[]`.

## Resolved issues

Closes #45 

### Before submitting the PR, please take the following into consideration
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.