### PR TITLE
fix: add types to exports to avoid typescript error in import

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "typings": "dist/types/lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/lib/index.d.ts",
       "import": "./dist/index.es.js",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
## Description

Added types to exports to prevent error in import for `moduleResolution: "Bundler"` like in screen bellow.

<img width="777" alt="image" src="https://github.com/roerohan/react-vnc/assets/80958304/b92c60f3-b40e-4ecb-a70d-01a42778650c">
