### PR TITLE
fix: Don't include `@rollup/plugin-typescript` in the published `package.json` 

### DIFF
--- a/prepublish.js
+++ b/prepublish.js
@@ -14,6 +14,7 @@ const {
 	"@types/react": typesReact,
 	"@types/react-dom": typesReactDom,
 	"web-vitals": webVitals,
+	"@rollup/plugin-typescript": rollupTypescriptPlugin,
 	...dependencies
 } = pkg.dependencies;
 


### PR DESCRIPTION
## Description

- Updates `prepublish.js` to not include `@rollup/plugin-typescript` in the published `package.json`
- I noticed ``@rollup/plugin-typescript` in my lockfile when I tried updating `react-vnc` to the latest version
- I'm pretty sure the package does not depend on `@rollup/plugin-typescript`  but correct me if I'm wrong. I didn't test this fix.

### Before submitting the PR, please take the following into consideration
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [ ] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.