### PR TITLE
feat: add missing event "clippingviewport"

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ interface Props {
     onBell?: EventListeners['bell'];
     onDesktopName?: EventListeners['desktopname'];
     onCapabilities?: EventListeners['capabilities'];
+    onClippingViewport?: EventListeners['clippingviewport'];
 }
 
 // The types NoVncOptions, NoVncEventType and NoVncEvents are from the

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@novnc/novnc": "^1.5.0",
-        "@types/novnc__novnc": "^1.5.0",
+        "@types/novnc__novnc": "^1.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "web-vitals": "^4.2.4"
@@ -3084,9 +3084,9 @@
       "dev": true
     },
     "node_modules/@types/novnc__novnc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/novnc__novnc/-/novnc__novnc-1.5.0.tgz",
-      "integrity": "sha512-9DrDJK1hUT6Cbp4t03IsU/DsR6ndnIrDgZVrzITvspldHQ7n81F3wUDfq89zmPM3wg4GErH11IQa0QuTgLMf+w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/novnc__novnc/-/novnc__novnc-1.6.0.tgz",
+      "integrity": "sha512-kIH/PQACbf9qj6whiSXRKECpyzgs6IFNVsW4wohyqQUZfQHdLhuGRMLi9XEhBiISSh0lKCSbBa7kScuPu9Gk+Q==",
       "license": "MIT"
     },
     "node_modules/@types/react": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.5.0",
-    "@types/novnc__novnc": "^1.5.0",
+    "@types/novnc__novnc": "^1.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "web-vitals": "^4.2.4"

--- a/src/lib/VncScreen.tsx
+++ b/src/lib/VncScreen.tsx
@@ -35,6 +35,7 @@ export interface Props {
     onBell?: EventListeners['bell'];
     onDesktopName?: EventListeners['desktopname'];
     onCapabilities?: EventListeners['capabilities'];
+    onClippingViewport?: EventListeners['clippingviewport'];
 }
 
 export type VncScreenHandle = {
@@ -89,6 +90,7 @@ const VncScreen: React.ForwardRefRenderFunction<VncScreenHandle, Props> = (props
         onBell,
         onDesktopName,
         onCapabilities,
+        onClippingViewport,
     } = props;
 
     const logger = {
@@ -227,6 +229,7 @@ const VncScreen: React.ForwardRefRenderFunction<VncScreenHandle, Props> = (props
             eventListeners.current.bell = onBell;
             eventListeners.current.desktopname = _onDesktopName;
             eventListeners.current.capabilities = onCapabilities;
+            eventListeners.current.clippingviewport = onClippingViewport;
 
             (Object.keys(eventListeners.current) as (NoVncEventType)[]).forEach((event) => {
                 if (eventListeners.current[event]) {


### PR DESCRIPTION
Update "@types/novnc__novnc" to version 1.6.0. & Add "clippingviewport" as a new event.

## Description

Update "@types/novnc__novnc" to version 1.6.0, which add the typings for the event:
[https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72476](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72476)

Add missing "clippingviewport" as a new event:
[https://github.com/novnc/noVNC/blob/master/docs/API.md#clippingviewport](https://github.com/novnc/noVNC/blob/master/docs/API.md#clippingviewport)


## Resolved issues

Closes #1