### PR TITLE
feat(vncscreen.tsx): Allow for customization of onMouseEnter and onMouseLeave events

### DIFF
--- a/src/lib/VncScreen.tsx
+++ b/src/lib/VncScreen.tsx
@@ -342,7 +342,16 @@ const VncScreen: React.ForwardRefRenderFunction<VncScreenHandle, Props> = (props
         handleClick();
     };
 
-    const handleMouseLeave = () => {
+    const handleMouseLeave = (e:any) => {
+        // https://github.com/roerohan/react-vnc/issues/5#issuecomment-1753065170
+        // FIXME: We see spurious mouse leave events in Chrome when the user clicks
+        // on the canvas.
+        // This hack drops the mouseleave event if the target is the window object.
+        if (e.relatedTarget) {
+            if (e.relatedTarget.window) {
+                return;
+            }
+        }
         const rfb = getRfb();
         if (!rfb) {
             return;


### PR DESCRIPTION
## Description

Currently the VncScreen component has hardcoded onMouseEnter and onMouseLeave events to focus and blur the noVNC rfb. This change allows customization of what happens with those events.

In the case of our project, the blurring on mouse leave is unnecessary and causes missed key-up events if a key is held when the mouse leaves the VncScreen component. Developers can customize behaviour by setting onChildMouseEnter and onChildMouseLeave as props on the VncScreen element.

This also modifies the default behavior of onMouseLeave to check if the target (cursor destination) is the noVNC mouse capture element. If the target is the noVNC mouse capture element it doesn't blur the rfb. This addresses the keyboard input issues caused by #5. Thanks to @richardstephens for the initial workaround which I cherry-picked into this branch.